### PR TITLE
CPUSテーブルのカラムを変更

### DIFF
--- a/db/migrate/20200312051258_create_cpus.rb
+++ b/db/migrate/20200312051258_create_cpus.rb
@@ -1,17 +1,17 @@
 class CreateCpus < ActiveRecord::Migration[5.2]
   def change
     create_table :cpus do |t|
-      t.string     :name,         null:false
-      t.integer    :price
-      t.integer    :core
-      t.integer    :thread
-      t.decimal    :clockspeed
-      t.decimal    :turbospeed
-      t.integer    :tdp
-      t.integer    :gpu
-      t.string     :image
-      t.date       :release_g
-      t.date       :release_ja
+      t.string      :name,       null:false
+      t.integer     :price
+      t.integer     :core
+      t.integer     :thread
+      t.decimal     :clockspeed, precision: 3, scale: 1
+      t.decimal     :turbospeed, precision: 3, scale: 1
+      t.integer     :tdp
+      t.integer     :gpu
+      t.string      :image
+      t.date        :release_g
+      t.date        :release_ja
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,8 +21,8 @@ ActiveRecord::Schema.define(version: 2020_03_12_063104) do
     t.integer "price"
     t.integer "core"
     t.integer "thread"
-    t.decimal "clockspeed", precision: 10
-    t.decimal "turbospeed", precision: 10
+    t.decimal "clockspeed", precision: 3, scale: 1
+    t.decimal "turbospeed", precision: 3, scale: 1
     t.integer "tdp"
     t.integer "gpu"
     t.string "image"


### PR DESCRIPTION
# what
CPUテーブルのclockspeedとturbospeedのカラムを全体で3桁、小数点以下1桁に変更した。
# why
デフォルトでは小数点以下を登録できないため